### PR TITLE
Optimize refund and adjustment queries

### DIFF
--- a/src/main/java/com/rbkmoney/payouter/dao/impl/AdjustmentDaoImpl.java
+++ b/src/main/java/com/rbkmoney/payouter/dao/impl/AdjustmentDaoImpl.java
@@ -76,14 +76,13 @@ public class AdjustmentDaoImpl extends AbstractGenericDao implements AdjustmentD
         Query query = getDslContext()
                 .update(ADJUSTMENT)
                 .set(ADJUSTMENT.PAYOUT_ID, payoutId)
-                .from(PAYMENT)
-                .where(ADJUSTMENT.INVOICE_ID.eq(PAYMENT.INVOICE_ID)
-                        .and(ADJUSTMENT.PAYMENT_ID.eq(PAYMENT.PAYMENT_ID))
-                        .and(PAYMENT.PARTY_ID.eq(partyId))
-                        .and(PAYMENT.SHOP_ID.eq(shopId))
-                        .and(PAYMENT.CAPTURED_AT.lessThan(to)))
-                .and(ADJUSTMENT.STATUS.eq(AdjustmentStatus.CAPTURED))
-                .and(ADJUSTMENT.PAYOUT_ID.isNull());
+                .where(
+                        ADJUSTMENT.PARTY_ID.eq(partyId)
+                                .and(ADJUSTMENT.SHOP_ID.eq(shopId))
+                                .and(ADJUSTMENT.CAPTURED_AT.lessThan(to))
+                                .and(ADJUSTMENT.STATUS.eq(AdjustmentStatus.CAPTURED))
+                                .and(ADJUSTMENT.PAYOUT_ID.isNull())
+                );
 
         return execute(query);
     }

--- a/src/main/java/com/rbkmoney/payouter/dao/impl/RefundDaoImpl.java
+++ b/src/main/java/com/rbkmoney/payouter/dao/impl/RefundDaoImpl.java
@@ -84,13 +84,12 @@ public class RefundDaoImpl extends AbstractGenericDao implements RefundDao {
         Query query = getDslContext()
                 .update(REFUND)
                 .set(REFUND.PAYOUT_ID, payoutId)
-                .from(PAYMENT)
-                .where(REFUND.INVOICE_ID.eq(PAYMENT.INVOICE_ID)
-                        .and(REFUND.PAYMENT_ID.eq(PAYMENT.PAYMENT_ID))
-                        .and(REFUND.PAYOUT_ID.isNull())
-                        .and(PAYMENT.PARTY_ID.eq(partyId))
-                        .and(PAYMENT.SHOP_ID.eq(shopId))
-                        .and(REFUND.STATUS.eq(RefundStatus.SUCCEEDED)));
+                .where(
+                        REFUND.PARTY_ID.eq(partyId)
+                                .and(REFUND.SHOP_ID.eq(shopId))
+                                .and(REFUND.PAYOUT_ID.isNull())
+                                .and(REFUND.STATUS.eq(RefundStatus.SUCCEEDED))
+                );
         return execute(query);
     }
 


### PR DESCRIPTION
Убран join на update при выборке рефандов и корректировок, так как заметил, что запросы в основном страдают не при обновлении платежей, а при обновлении рефандов, так как используется этот join, который в принципе и не нужен.